### PR TITLE
Add tests for APIs and components

### DIFF
--- a/__tests__/api/events-api.test.js
+++ b/__tests__/api/events-api.test.js
@@ -1,0 +1,28 @@
+/** @jest-environment node */
+import handler from '../../pages/api/events';
+import { connectToDatabase } from '../../libs/database';
+import { createMocks } from 'node-mocks-http';
+
+jest.mock('../../libs/database');
+
+describe('events API handler', () => {
+  it('responds with event data on GET', async () => {
+    const date = new Date('2025-06-21T00:00:00Z');
+    const mockEvents = [{ event_name: 'Demo', event_end_date: date }];
+    const toArray = jest.fn().mockResolvedValue(mockEvents);
+    const sort = jest.fn().mockReturnValue({ toArray });
+    const limit = jest.fn().mockReturnValue({ sort });
+    const find = jest.fn().mockReturnValue({ limit });
+    const collection = { find };
+    connectToDatabase.mockResolvedValue({ db: { collection: jest.fn(() => collection) } });
+
+    const { req, res } = createMocks({ method: 'GET', query: { limit: '1' } });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      count: 1,
+      eventsArray: [{ event_name: 'Demo', event_end_date: date.toISOString() }],
+    });
+  });
+});

--- a/__tests__/api/hppstatus-api.test.js
+++ b/__tests__/api/hppstatus-api.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+import handler from '../../pages/api/hppstatus';
+import { connectToDatabase } from '../../libs/database';
+import { createMocks } from 'node-mocks-http';
+
+jest.mock('../../libs/database');
+
+describe('hppstatus API handler', () => {
+  beforeAll(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-06-21T00:00:00Z'));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('responds with computed status', async () => {
+    const now = new Date('2025-06-21T00:00:00Z');
+    const records = [
+      { timestamp: new Date(now.getTime() - 2 * 86400000).toISOString(), value: false },
+      { timestamp: new Date(now.getTime() - 1 * 86400000).toISOString(), value: true }
+    ];
+    const collection = {
+      find: jest.fn(() => ({ toArray: jest.fn().mockResolvedValue(records) }))
+    };
+    connectToDatabase.mockResolvedValue({ db: { collection: jest.fn(() => collection) } });
+
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({
+      currentStatus: true,
+      lastChangedDate: '2025-06-19',
+      effectiveLastOpenDate: '2025-06-19',
+      closuresInLast7Days: 1,
+      closuresInLast28Days: 1,
+      closuresInLast182Days: 1,
+      closuresInLast365Days: 1,
+    });
+  });
+});

--- a/__tests__/chartrender.test.js
+++ b/__tests__/chartrender.test.js
@@ -1,0 +1,25 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import ChartRender from '../components/functional/chart';
+
+jest.mock('react-google-charts', () => props => {
+  return <div data-testid="chart" data={JSON.stringify(props.data)}></div>;
+});
+
+describe('ChartRender component', () => {
+  it('renders chart with data rows', async () => {
+    const graphData = [
+      { reading_date: '2025-06-19T00:00:00Z', reading_level: 1.2 }
+    ];
+    const graphForecastData = [
+      { forecast_date: '2025-06-20T00:00:00Z', forecast_reading: 1.3 }
+    ];
+    render(
+      <ChartRender graphData={graphData} graphForeCastData={graphForecastData} lowerBound={0.5} upperBound={2.0} />
+    );
+    await waitFor(() => {
+      const el = screen.getByTestId('chart');
+      const data = JSON.parse(el.getAttribute('data'));
+      expect(data.length).toBe(1 + graphData.length + graphForecastData.length + 1);
+    });
+  });
+});

--- a/__tests__/eventsform.test.js
+++ b/__tests__/eventsform.test.js
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import EventsForm from '../components/functional/eventsform';
+import axios from 'axios';
+
+jest.mock('axios');
+
+describe('EventsForm component', () => {
+  it('shows validation errors for invalid fields', async () => {
+    render(
+      <EventsForm
+        id={1}
+        name=""
+        startDate={new Date('2025-06-21')}
+        endDate={new Date('2025-06-20')}
+        eventDetails=""
+        isNew={true}
+        mutate={jest.fn()}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.blur(screen.getByLabelText(/Event Name/));
+      fireEvent.blur(screen.getByLabelText(/Event End Date/));
+      fireEvent.blur(screen.getByLabelText(/Event Details/));
+    });
+
+    expect(await screen.findByText(/Event name is required/)).toBeInTheDocument();
+    expect(await screen.findByText(/before start date/)).toBeInTheDocument();
+    expect(await screen.findByText(/Event details are required/)).toBeInTheDocument();
+  });
+
+  it('submits valid data', async () => {
+    axios.post.mockResolvedValue({ status: 200 });
+    render(
+      <EventsForm
+        id={1}
+        name="Test Event"
+        startDate={new Date('2025-06-21')}
+        endDate={new Date('2025-06-22')}
+        eventDetails="Details"
+        isNew={true}
+        mutate={jest.fn()}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Save Edit|Add Event/i }));
+    });
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "formik": "^2.2.6",
         "leaflet": "^1.9.4",
         "mongodb": "^3.6.3",
+        "next": "^15.2.2",
         "next-auth": "^4.17.0",
         "qs": "^6.10.3",
         "react": "^19.0.0",
@@ -33,7 +34,7 @@
         "eslint-config-next": "^15.2.2",
         "jest": "^30.0.2",
         "jest-environment-jsdom": "^30.0.2",
-        "next": "^15.3.4"
+        "node-mocks-http": "^1.17.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3216,6 +3217,20 @@
         }
       }
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -4059,6 +4074,19 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4292,6 +4320,16 @@
       "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/dequal": {
@@ -5346,6 +5384,16 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fs.realpath": {
@@ -7680,11 +7728,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7702,6 +7770,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7713,6 +7791,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -7868,6 +7959,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "15.3.4",
       "resolved": "https://registry.npmjs.org/next/-/next-15.3.4.tgz",
@@ -7959,6 +8060,40 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-mocks-http": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.17.2.tgz",
+      "integrity": "sha512-HVxSnjNzE9NzoWMx9T9z4MLqwMpLwVvA0oVZ+L+gXskYXEJ6tFn3Kx4LargoB6ie7ZlCLplv7QbWO6N+MysWGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.21 || ^5.0.0",
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
@@ -8308,6 +8443,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8628,6 +8773,16 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/react": {
       "version": "19.0.0",
@@ -9992,6 +10147,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@testing-library/user-event": "^14.6.1",
     "eslint-config-next": "^15.2.2",
     "jest": "^30.0.2",
-    "jest-environment-jsdom": "^30.0.2"
+    "jest-environment-jsdom": "^30.0.2",
+    "node-mocks-http": "^1.17.2"
   }
 }


### PR DESCRIPTION
## Summary
- add test coverage for `events` API
- test `hppstatus` API logic
- create component tests for `EventsForm` and chart rendering
- include `node-mocks-http` as dev dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f08b827c832d8bf3ff3c0a3c8f39