### PR TITLE
Fix eventsform revalidation

### DIFF
--- a/components/functional/eventsform.js
+++ b/components/functional/eventsform.js
@@ -56,7 +56,10 @@ export default function EventsForm({ id, name, startDate, endDate, eventDetails,
             const response = await axios.post("/api/events", JSON.stringify(dataArray), { withCredentials: true });
             if (response.status === 200) {
               setSuccess(true);
-              mutate("/api/events");
+              // Revalidate events data so the table reflects the update
+              // Passing no arguments uses the bound mutate from useSWR
+              // which will refetch the data for the current key
+              mutate();
             } else {
               setError("Error modifying event!");
             }


### PR DESCRIPTION
## Summary
- ensure mutate() is invoked correctly after submitting an event

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68570dbbefd4832db71f190bcc9f260b